### PR TITLE
Updated readme with example for Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 - Open `~/.hyperterm.js`
 - Add `hyperterm-working-directory` to the list of `plugins`
-- Set `config.workingDirectory` to something like `~/dev`
+- Set `config.workingDirectory` to something like `~/dev` (note that on Windows you will need to use \\ to escape the backslash. e.g. `C:\\Working\\Directory\\Example`)
 
 That's it. If `config.workingDirectory` is not set, a default value of `$HOME` will be used.
 


### PR DESCRIPTION
On Windows you need to escape the backslashes in the path otherwise Hyper will throw an exception on load.

And for extra reading I enjoy this XKCD on this topic: https://xkcd.com/1638/

Please feel free to suggest improvements or change the PR yourself. Thanks for this really helpful plugin!
I also realise it is normal to have to escape backslashes in JSON but might not be immediately obvious if you paste a Windows folder path into the config.